### PR TITLE
Clarify wording of 'listen' message

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var runServer = function(callback) {
     mongoose.connect(databaseUri).then(function() {
         var port = process.env.PORT || 8080;
         var server = app.listen(port, function() {
-            console.log('Listening on localhost:' + port);
+            console.log('Listening on port ' + port);
             if (callback) {
                 callback(server);
             }


### PR DESCRIPTION
The notation "localhost:8080" has a very specific, technical meaning. In this instance, the app is actually listening on 0.0.0.0:8080 or :::8080 (depending on the availability of IPv6). For safety's sake, avoid the incorrect "localhost", and go for generic wording.
