### PR TITLE
Replace deprecated Mongoose Promise with global promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var express = require('express');
 var bodyParser = require('body-parser');
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
 
 var app = express();
 
@@ -27,4 +28,3 @@ if (require.main === module) {
 
 exports.app = app;
 exports.runServer = runServer;
-

--- a/test/test-message.js
+++ b/test/test-message.js
@@ -3,6 +3,7 @@ global.databaseUri = 'mongodb://localhost/sup-dev';
 var chai = require('chai');
 var chaiHttp = require('chai-http');
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
 var UrlPattern = require('url-pattern');
 var app = require('../index').app;
 

--- a/test/test-user.js
+++ b/test/test-user.js
@@ -3,6 +3,7 @@ global.databaseUri = 'mongodb://localhost/sup-dev';
 var chai = require('chai');
 var chaiHttp = require('chai-http');
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
 var UrlPattern = require('url-pattern');
 var app = require('../index').app;
 


### PR DESCRIPTION
See Mongoose issue below for details:
Automattic/mongoose#4291

Change to global promise should not require any syntax changes, but will resolve and eliminate the deprecation warning. Does not require any new packages.
